### PR TITLE
feat: resolve `core_version` at install time instead of at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,16 @@ jobs:
       # `uses: ./` installs into the workspace checkout, so ./node_modules is the action's tree.
       # Checks input -> package.json spec -> installed version;
       # `pnpm info` lists every version matching the spec, highest last.
+      #
+      # Depends on core being listed in `minimumReleaseAgeExclude` (pnpm-workspace.yaml).
+      # Without it, `pnpm info` would report a release that pnpm still refuses to install,
+      # so this would fail for `minimumReleaseAge`after every core publish.
+      #
+      # `pkg get` needs the bracket form: pnpm 11 rejects `@` in a dot property
+      # path with ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH.
       - name: Assert the installed core version matches core_version
         run: |
-          spec=$(pnpm pkg get "dependencies.$PKG" | tr -d '"')
+          spec=$(pnpm pkg get "dependencies[\"$PKG\"]" | tr -d '"')
           expected=$(pnpm info "$PKG@$spec" version | tail -1 | tr -d "'" | awk '{print $NF}')
           installed=$(pnpm list --depth 0 "$PKG" | grep -F "$PKG@" | sed 's/.*@//')
           echo "input='$CORE_VERSION' spec='$spec' expected='$expected' installed='$installed'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,80 @@ jobs:
           PAT_1: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: "rickstaa"
 
+  action:
+    name: Action (core_version ${{ matrix.core_version || 'empty' }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        core_version: ["", "2.1.3", "v2"]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate stats card
+        id: generate
+        uses: ./
+        with:
+          card: stats
+          options: username=rickstaa
+          path: profile/stats.svg
+          core_version: ${{ matrix.core_version }}
+
+      - name: Assert the card was written
+        run: grep -q "<svg" "${{ steps.generate.outputs.path }}"
+        shell: bash
+
+      # `uses: ./` installs into the workspace checkout, so ./node_modules is the action's tree.
+      # Checks input -> package.json spec -> installed version;
+      # `pnpm info` lists every version matching the spec, highest last.
+      - name: Assert the installed core version matches core_version
+        run: |
+          spec=$(pnpm pkg get "dependencies.$PKG" | tr -d '"')
+          expected=$(pnpm info "$PKG@$spec" version | tail -1 | tr -d "'" | awk '{print $NF}')
+          installed=$(pnpm list --depth 0 "$PKG" | grep -F "$PKG@" | sed 's/.*@//')
+          echo "input='$CORE_VERSION' spec='$spec' expected='$expected' installed='$installed'"
+          [ -z "$CORE_VERSION" ] || [ "$spec" = "$CORE_VERSION" ] || { echo "::error::spec '$spec' does not match core_version '$CORE_VERSION'"; exit 1; }
+          [ "$installed" = "$expected" ] || { echo "::error::installed core '$installed', expected '$expected' for spec '$spec'"; exit 1; }
+        shell: bash
+        env:
+          CORE_VERSION: ${{ matrix.core_version }}
+          PKG: "@stats-organization/github-readme-stats-core"
+
+  action-invalid-core-version:
+    name: Action rejects an invalid core_version
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate stats card
+        id: generate
+        continue-on-error: true
+        uses: ./
+        with:
+          card: stats
+          options: username=rickstaa
+          core_version: "latest && whoami"
+
+      - name: Assert the action failed
+        run: |
+          if [ "${{ steps.generate.outcome }}" != "failure" ]; then
+            echo "::error::expected the action to reject the core_version input"
+            exit 1
+          fi
+        shell: bash
+
   code-checks:
     name: Code checks
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ This action is a recommended deployment option. You can also use [our public Git
 - `options`: Card options as a query string (`key=value&...`) or JSON. If `username` is omitted, the action uses the repository owner.
 - `path`: Output path for the SVG file. Defaults to `profile/<card>.svg`.
 - `token`: GitHub token (PAT or `GITHUB_TOKEN`). For private repo stats, use a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `repo` and `read:user` scopes. For any gist, use a PAT with `gist` scope.
-- `core_version`: Version of [GitHub Stats Extended](https://github.com/stats-organization/github-stats-extended) to use internally. When omitted, the action uses the latest 2.x.x version.
+- `core_version`: Version of [GitHub Stats Extended](https://github.com/stats-organization/github-stats-extended) to use internally. Accepts any npm version, range or dist-tag (`2.1.3`, `v2`, `latest`).\
+  When omitted, the action uses the latest 2.x.x version. Set an exact version for reproducible runs, or an empty string to use the version pinned by the action release you reference.
 - `fail_on_error`: Fail the action when data fetching fails (e.g. a GitHub API rate limit) instead of writing the "Something went wrong" error card.\
   Defaults to `false` for backwards compatibility.
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: GitHub Readme Stats Action
 description: Generate GitHub Readme Stats cards in GitHub Actions.
 author: stats-organization
+
 inputs:
   card:
     description: Card type to generate (stats, top-langs, pin, wakatime, gist).
@@ -18,15 +19,17 @@ inputs:
     required: false
     default: ""
   core_version:
-    description: Version of @stats-organization/github-readme-stats-core to use internally.
+    description: >-
+      Version of @stats-organization/github-readme-stats-core to use internally (any npm version, range or dist-tag).
+      Defaults to the latest 2.x. 
+      Set to an empty string to use the version pinned by this action release instead.
     required: false
     default: "v2"
   fail_on_error:
     description: >-
-      Fail the action when the card renderer reports a data-fetch error (e.g. a
-      GitHub API rate limit) instead of writing the "Something went wrong" error
-      card. Defaults to "false" to preserve backwards-compatible behaviour; set
-      to "true" to fail the action on a broken card.
+      Fail the action when the card renderer reports a data-fetch error 
+      (e.g. a GitHub API rate limit) instead of writing the "Something went wrong" error card.
+      Defaults to "false" to preserve backwards-compatible behavior; set to "true" to fail the action on a broken card.
     required: false
     default: "false"
 outputs:
@@ -55,9 +58,29 @@ runs:
       # --prod skips devDependencies (husky, vitest, etc.); --ignore-scripts skips the
       # husky prepare hook, which would otherwise fail since husky isn't installed.
       # https://github.com/stats-organization/github-readme-stats-action/issues/63
-      run: pnpm install --frozen-lockfile --prod --ignore-scripts
+      #
+      # `core_version` is applied here so index.js can use plain node_modules
+      # resolution. It arrives via env (never interpolated) and is validated.
+      # --no-lockfile is required: with a lockfile pnpm keeps the locked version
+      # whenever it satisfies the new range, so "v2" would resolve to the pin.
+      run: |
+        if [ -n "$CORE_VERSION" ]; then
+          case "$CORE_VERSION" in
+            *[!a-zA-Z0-9._-]*)
+              echo "::error::core_version must contain only a-zA-Z0-9._- characters."
+              exit 1
+              ;;
+          esac
+          pnpm pkg set "dependencies.$CORE_PACKAGE_NAME=$CORE_VERSION"
+          pnpm install --no-lockfile --prod --ignore-scripts
+        else
+          pnpm install --frozen-lockfile --prod --ignore-scripts
+        fi
       shell: bash
       working-directory: ${{ github.action_path }}
+      env:
+        CORE_VERSION: ${{ inputs.core_version }}
+        CORE_PACKAGE_NAME: "@stats-organization/github-readme-stats-core"
     - name: Generate card
       id: generate
       run: node ${{ github.action_path }}/index.js
@@ -66,9 +89,9 @@ runs:
         INPUT_CARD: ${{ inputs.card }}
         INPUT_OPTIONS: ${{ inputs.options }}
         INPUT_PATH: ${{ inputs.path }}
-        INPUT_CORE_VERSION: ${{ inputs.core_version }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         PAT_1: ${{ inputs.token || github.token }}
+
 branding:
   icon: bar-chart-2
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,11 @@ runs:
       # resolution. It arrives via env (never interpolated) and is validated.
       # --no-lockfile is required: with a lockfile pnpm keeps the locked version
       # whenever it satisfies the new range, so "v2" would resolve to the pin.
+      # The lockfile is removed rather than left in place only to avoid pnpm
+      # warning that it exists but is being ignored.
+      #
+      # `pkg set` needs the bracket form: pnpm 11 rejects `@` in a dot property
+      # path with ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH.
       run: |
         if [ -n "$CORE_VERSION" ]; then
           case "$CORE_VERSION" in
@@ -71,7 +76,8 @@ runs:
               exit 1
               ;;
           esac
-          pnpm pkg set "dependencies.$CORE_PACKAGE_NAME=$CORE_VERSION"
+          pnpm pkg set "dependencies[\"$CORE_PACKAGE_NAME\"]=$CORE_VERSION"
+          rm -f pnpm-lock.yaml
           pnpm install --no-lockfile --prod --ignore-scripts
         else
           pnpm install --frozen-lockfile --prod --ignore-scripts

--- a/index.js
+++ b/index.js
@@ -1,73 +1,10 @@
-import { exec } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
-import os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 
 import { getInput, info, setFailed, setOutput, warning } from "@actions/core";
 
-const execAsync = promisify(exec);
 const CORE_PACKAGE_NAME = "@stats-organization/github-readme-stats-core";
 const supportedCoreExports = ["api", "topLangs", "pin", "wakatime", "gist"];
-
-const validateCoreVersion = (value) => {
-  const pattern = /^[a-zA-Z0-9._-]*$/;
-  if (!pattern.test(value)) {
-    throw new Error("core_version must contain only a-zA-Z0-9._- characters.");
-  }
-  return value;
-};
-
-/**
- * Install the requested core package into an isolated temporary directory.
- * @param {string} version Package version.
- * @returns {Promise<string>} Directory containing the installed package.
- */
-const installCorePackage = async (version) => {
-  const installDir = await mkdtemp(path.join(os.tmpdir(), "grs-core-"));
-  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-  const packageSpec = `${CORE_PACKAGE_NAME}@${version}`;
-
-  try {
-    await writeFile(
-      path.join(installDir, "package.json"),
-      JSON.stringify({ private: true, type: "module" }),
-      "utf8",
-    );
-
-    await execAsync(
-      `${npmCommand} install --no-save --ignore-scripts --no-package-lock ${packageSpec}`,
-      {
-        cwd: installDir,
-        env: process.env,
-      },
-    );
-
-    return installDir;
-  } catch (error) {
-    throw new Error(
-      `Failed to install ${CORE_PACKAGE_NAME}@${version}: ${error}`,
-    );
-  }
-};
-
-/**
- * Load the core package either from the bundled dependency or from an isolated install.
- * @param {string} version Package version.
- * @returns {Promise<Record<string, unknown>>} Loaded module and cleanup callback.
- */
-const loadCoreModule = async (version) => {
-  if (!version) {
-    return await import(CORE_PACKAGE_NAME);
-  }
-
-  const installDir = await installCorePackage(version);
-  const installRequire = createRequire(path.join(installDir, "package.json"));
-  const modulePath = installRequire.resolve(CORE_PACKAGE_NAME);
-  return await import(pathToFileURL(modulePath).href);
-};
 
 /**
  * Build the map of supported card handlers from the loaded core module.
@@ -183,10 +120,11 @@ const run = async () => {
   const card = getInput("card", { required: true }).toLowerCase();
   const optionsInput = getInput("options");
   const outputPathInput = getInput("path");
-  const coreVersion = validateCoreVersion(getInput("core_version"));
   const failOnError = /^(true|1|yes)$/i.test(getInput("fail_on_error"));
 
-  const coreModule = await loadCoreModule(coreVersion);
+  // `core_version` is applied by the action's install step.
+  // Dynamic so a broken install surfaces through `setFailed` instead of a raw module-load error.
+  const coreModule = await import(CORE_PACKAGE_NAME);
 
   // Map of card types to their respective API handlers.
   const cardHandlers = createCardHandlers(coreModule);

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,4 +1,12 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  "ignoreDependencies": ["@stats-organization/github-readme-stats-core"]
+
+  // index.js loads the core package with `await import(CORE_PACKAGE_NAME)`. The
+  // specifier is a variable, so knip cannot resolve it and reports the
+  // dependency as unused.
+  "ignoreDependencies": ["@stats-organization/github-readme-stats-core"],
+
+  // ci.yml calls `pnpm info` to resolve a version spec against the registry.
+  // knip does not know that pnpm subcommand and reads `info` as a binary.
+  "ignoreBinaries": ["info"]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:knip": "knip"
   },
   "dependencies": {
-    "@actions/core": "^3.0.1",
+    "@actions/core": "3.0.1",
     "@stats-organization/github-readme-stats-core": "2.1.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@actions/core':
-        specifier: ^3.0.1
+        specifier: 3.0.1
         version: 3.0.1
       '@stats-organization/github-readme-stats-core':
         specifier: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # Deliberately stricter than pnpm 11's 1440 default (7 days vs 1)
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  # core is excluded so `core_version` stays honest: a caller asking for `latest` or
+  # `v2` must get the newest matching release, not one held back for a week.
+  # It also keeps the CI assertion that compares the installed version against `pnpm info`
+  # from failing for 7 days after every core publish.
   - "@stats-organization/github-readme-stats-core"
 
 # Reject a version with weaker publish trust evidence than an earlier one.

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -13,7 +13,7 @@ const rootDir = path.resolve(
 const repoOwner = process.env.GITHUB_REPOSITORY_OWNER ?? "rickstaa";
 let buildDir;
 
-const runCard = (card, options, output, coreVersion, extraEnv = {}) =>
+const runCard = (card, options, output, extraEnv = {}) =>
   new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [path.join(rootDir, "index.js")], {
       stdio: "inherit",
@@ -22,7 +22,6 @@ const runCard = (card, options, output, coreVersion, extraEnv = {}) =>
         INPUT_CARD: card,
         INPUT_OPTIONS: options,
         INPUT_PATH: output,
-        INPUT_CORE_VERSION: coreVersion,
         ...extraEnv,
       },
     });
@@ -95,15 +94,9 @@ describe.concurrent("generate cards locally", () => {
     const errorPath = path.join(buildDir, "error-fails.svg");
 
     await expect(
-      runCard(
-        "stats",
-        `username=${repoOwner}&locale=zzinvalid`,
-        errorPath,
-        "",
-        {
-          INPUT_FAIL_ON_ERROR: "true",
-        },
-      ),
+      runCard("stats", `username=${repoOwner}&locale=zzinvalid`, errorPath, {
+        INPUT_FAIL_ON_ERROR: "true",
+      }),
     ).rejects.toThrow();
 
     // The error card must not be written when the action fails.
@@ -120,41 +113,4 @@ describe.concurrent("generate cards locally", () => {
     expect(data).toContain("<svg");
     expect(data).toContain("Something went wrong");
   });
-
-  test("rejects invalid core_version input before install", async () => {
-    const invalidVersionPath = path.join(buildDir, "invalid-version.svg");
-
-    await expect(
-      runCard(
-        "stats",
-        `username=${repoOwner}`,
-        invalidVersionPath,
-        "latest && whoami",
-      ),
-    ).rejects.toThrow();
-  });
 });
-
-describe("include requested core package versions", () => {
-  test("use core package version 'v2'", async () => {
-    const v2Path = path.join(buildDir, "v2.svg");
-
-    await runCard("stats", `username=${repoOwner}`, v2Path, "v2");
-    await assertSvg(v2Path);
-  });
-
-  test("use core package version 'latest'", async () => {
-    const latestPath = path.join(buildDir, "latest.svg");
-
-    await runCard("stats", `username=${repoOwner}`, latestPath, "latest");
-    await assertSvg(latestPath);
-  });
-
-  test("core package version 'abcdef' fails", async () => {
-    const abcdefPath = path.join(buildDir, "abcdef.svg");
-
-    await expect(
-      runCard("stats", `username=${repoOwner}`, abcdefPath, "abcdef"),
-    ).rejects.toThrow();
-  });
-}, 20_000);


### PR DESCRIPTION
`index.js` `npm install`ed core into a temp dir on every run, while the core pin in `package.json` was installed by the action and never used.
The install step now applies the version, so `index.js` uses plain `node_modules` resolution.
No behaviour change: `core_version` still defaults to `v2` and resolves to the latest 2.x.

- `index.js`: temp-install machinery replaced by a single `await import()`.
- `action.yml`: validates `core_version` and applies it with `pnpm pkg set`, installing once. `--no-lockfile` is needed, otherwise pnpm keeps the locked version and `v2` silently resolves to the pin.
- Tests: version-selection moves out of `tests/e2e.test.js` into CI jobs covering `core_version` of `v2`, `2.1.3`, empty, and an invalid value.

> [!NOTE]
> Because that path installs without a lockfile, `@actions/core` is now pinned exactly, a range would float where the lockfile used to hold it.
> Later dependencies need the same.
